### PR TITLE
Adds support for dynamic handler notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ ssl_certificate_permissions_map:
 # configured yet. Usernames include in the list below will be created as
 # system accounts and groups prior to managing the permissions map.
 ssl_certificate_create_users: []
+
+# Dynamic handler support for restarting services in parent roles.
+# Simply declare a list of strings, e.g. "restart apache2", and the
+# associated handler will be called. The parent role must provide the handler.
+ssl_certificate_dynamic_handlers: []
 ```
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,3 +31,8 @@ ssl_certificate_permissions_map:
 # configured yet. Usernames include in the list below will be created as
 # system accounts and groups prior to managing the permissions map.
 ssl_certificate_create_users: []
+
+# Dynamic handler support for restarting services in parent roles.
+# Simply declare a list of strings, e.g. "restart apache2", and the
+# associated handler will be called. The parent role must provide the handler.
+ssl_certificate_dynamic_handlers: []

--- a/tasks/generate_cert.yml
+++ b/tasks/generate_cert.yml
@@ -35,6 +35,7 @@
     -out {{ ssl_certificate_permissions_map.cert.path }}
   when: existing_openssl_cert_result.stat.exists == false
         or ssl_certificate_force_generate == true
+  notify: "{{ ssl_certificate_dynamic_handlers }}"
 
 - name: Set permissions on OpenSSL files.
   become: yes


### PR DESCRIPTION
The keypair generated by this role will surely be associated with a
service of some kind. If swapping the cert should notify a handler,
simply declare the handler(s) via the list var. Provided the parent
role ships with the named handler, this role will run it without issue.

By default, of course, no handlers are notified, since the var value
defaults to an empty list.